### PR TITLE
Implement default device aware audio sink

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,15 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libasound2-dev libudev-dev libxi-dev libxtst-dev libxdo-dev
+        sudo apt-get install -y \
+          libasound2-dev \
+          libudev-dev \
+          libxi-dev \
+          libxtst-dev \
+          libxdo-dev \
+          libxcb-render0-dev \
+          libxcb-shape0-dev \
+          libxcb-xfixes0-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/default_device_sink.rs
+++ b/src/default_device_sink.rs
@@ -1,0 +1,135 @@
+use std::sync::{Arc, Mutex};
+use cpal::traits::{DeviceTrait, HostTrait};
+use rodio::{OutputStream, Sink, Source};
+
+/// Returns the name of the current default output device, if any.
+fn default_device_name() -> Option<String> {
+    cpal::default_host()
+        .default_output_device()
+        .and_then(|d| d.name().ok())
+}
+
+struct Inner {
+    _stream: OutputStream,
+    sink: Sink,
+    device_name: Option<String>,
+}
+
+/// `DefaultDeviceSink` wraps a `rodio::Sink` and recreates the underlying
+/// stream and sink if the system default output device changes.
+#[derive(Clone)]
+pub struct DefaultDeviceSink {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl DefaultDeviceSink {
+    /// Creates a new `DefaultDeviceSink` using the system default output device.
+    pub fn new() -> Self {
+        let (stream, handle) = OutputStream::try_default()
+            .expect("Failed to open default output stream");
+        let sink = Sink::try_new(&handle).expect("Failed to create Sink");
+        let name = default_device_name();
+        DefaultDeviceSink {
+            inner: Arc::new(Mutex::new(Inner {
+                _stream: stream,
+                sink,
+                device_name: name,
+            })),
+        }
+    }
+
+    /// Checks if the default output device has changed. If so, recreates the
+    /// stream and sink so future sounds play on the new device.
+    fn ensure_device(inner: &mut Inner) {
+        let current = default_device_name();
+        if current != inner.device_name {
+            let (stream, handle) = OutputStream::try_default()
+                .expect("Failed to open default output stream");
+            let sink = Sink::try_new(&handle).expect("Failed to create Sink");
+            // Stop old sink so it doesn't continue playing.
+            inner.sink.stop();
+            inner._stream = stream;
+            inner.sink = sink;
+            inner.device_name = current;
+        }
+    }
+
+    /// Appends a source to the sink, ensuring that the default device is current.
+    pub fn append<S>(&self, source: S)
+    where
+        S: Source + Send + 'static,
+        S::Item: rodio::Sample + Send,
+        f32: cpal::FromSample<S::Item>,
+    {
+        let mut inner = self.inner.lock().unwrap();
+        Self::ensure_device(&mut inner);
+        inner.sink.append(source);
+    }
+
+    /// Stops playback and clears queued sounds.
+    pub fn stop(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.stop();
+    }
+
+    pub fn play(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.play();
+    }
+
+    pub fn pause(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.pause();
+    }
+
+    pub fn is_paused(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.is_paused()
+    }
+
+    pub fn clear(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.clear();
+    }
+
+    pub fn skip_one(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.skip_one();
+    }
+
+    pub fn sleep_until_end(&self) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.sleep_until_end();
+    }
+
+    pub fn empty(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.empty()
+    }
+
+    pub fn len(&self) -> usize {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.len()
+    }
+
+    pub fn volume(&self) -> f32 {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.volume()
+    }
+
+    pub fn set_volume(&self, value: f32) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.set_volume(value);
+    }
+
+    pub fn speed(&self) -> f32 {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.speed()
+    }
+
+    pub fn set_speed(&self, value: f32) {
+        let inner = self.inner.lock().unwrap();
+        inner.sink.set_speed(value);
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::filter::FilterFn;
 use tracing_subscriber::Registry;
 mod timers;
 mod transcribe;
+mod default_device_sink;
 use chrono::{DateTime, Local};
 use futures::stream::StreamExt; // For `.next()` on FuturesOrdered.
 use std::thread;
@@ -742,7 +743,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(voice) => voice.into(),
         None => Voice::Echo,
     };
-    let (speak_stream, _stream) = ss::SpeakStream::new(ai_voice, opt.speech_speed);
+    let speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed);
     let speak_stream_mutex = Arc::new(Mutex::new(speak_stream));
 
     match opt.subcommands {

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -13,6 +13,7 @@ use std::{
 use tracing::{info, warn};
 
 use crate::CACHE_DIR;
+use crate::default_device_sink::DefaultDeviceSink;
 
 // Global atomic ID counter for timers
 static NEXT_ID: LazyLock<AtomicU64> = LazyLock::new(|| AtomicU64::new(1));
@@ -140,8 +141,7 @@ impl AudibleTimers {
             flume::unbounded();
 
         thread::spawn(move || {
-            let (_stream, stream_handle) = rodio::OutputStream::try_default().unwrap();
-            let sink = rodio::Sink::try_new(&stream_handle).unwrap();
+            let sink = DefaultDeviceSink::new();
 
             let mut timer_error_was_logged = false;
 


### PR DESCRIPTION
## Summary
- create `DefaultDeviceSink` to recreate `rodio::Sink` when default audio device changes
- use `DefaultDeviceSink` in `SpeakStream`
- adjust `SpeakStream::new` signature and update call sites

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684129eafbb4833294af09c8a7b540be