### PR TITLE
Add system setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ The assistant has functions for controling the desktop. Such as:
 - Run internet speedtests
 - Set timers that end in alarm sounds
 - Set the system clipboard
+
+## Setup
+
+Run the setup script to install system dependencies:
+
+```bash
+./setup.sh
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo apt-get update
+sudo apt-get install -y libasound2-dev libudev-dev libxi-dev libxtst-dev libxdo-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev


### PR DESCRIPTION
## Summary
- provide `setup.sh` to install system dependencies
- document running `setup.sh` in README

## Testing
- `cargo test` *(fails: `alsa` system library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413395e6308332ab7208806a609112