### PR TITLE
Add runtime voice speed controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The assistant has functions for controlling the desktop. Such as:
 - Run internet speed tests
 - Set timers that end in alarm sounds
 - Set the system clipboard
+- Change the AI voice speed during conversation
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- allow adjusting AI speech speed at runtime
- expose new `set_speech_speed` and `get_speech_speed` functions
- update ChatGPT function descriptions and README

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68414ed0e3dc8332ab8e0477a1ca0290