### PR TITLE
Fix TTS failure tick

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -785,7 +785,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(voice) => voice.into(),
         None => Voice::Echo,
     };
-    let (speak_stream, speak_state_rx) = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick);
+    let speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick);
     let speak_stream_mutex = Arc::new(Mutex::new(speak_stream));
 
     match opt.subcommands {


### PR DESCRIPTION
## Summary
- ensure state updates always reach the tick thread
- simplify `SpeakStream::new` to return only the stream

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684909ca18848332898571f21c6725e0