### PR TITLE
Add mute flag and self-mute functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The assistant has functions for controlling the desktop. Such as:
 - Set timers that end in alarm sounds
 - Set the system clipboard
 - Change the AI voice speed during conversation
+- Mute or unmute the AI voice during conversation (use `--mute` to start muted)
 
 ## Setup
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -493,6 +493,18 @@ fn call_fn(
             ))
         }
 
+        "mute_speech" => {
+            let mut speak_stream = speak_stream_mutex.lock().unwrap();
+            speak_stream.mute();
+            Some("AI voice muted".to_string())
+        }
+
+        "unmute_speech" => {
+            let mut speak_stream = speak_stream_mutex.lock().unwrap();
+            speak_stream.unmute();
+            Some("AI voice unmuted".to_string())
+        }
+
         _ => {
             println!("Unknown function: {}", fn_name);
             warn!("AI called unknown function: {}", fn_name);
@@ -785,7 +797,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(voice) => voice.into(),
         None => Voice::Echo,
     };
-    let speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick);
+    let mut speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick);
+    if opt.mute {
+        speak_stream.mute();
+    }
     let speak_stream_mutex = Arc::new(Mutex::new(speak_stream));
 
     match opt.subcommands {
@@ -1331,6 +1346,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 ChatCompletionFunctionsArgs::default()
                                     .name("get_speech_speed")
                                     .description("Returns the current AI voice speech speed.")
+                                    .parameters(json!({
+                                        "type": "object",
+                                        "properties": {},
+                                        "required": [],
+                                    }))
+                                    .build().unwrap(),
+
+                                ChatCompletionFunctionsArgs::default()
+                                    .name("mute_speech")
+                                    .description("Mutes the AI voice so no speech is played.")
+                                    .parameters(json!({
+                                        "type": "object",
+                                        "properties": {},
+                                        "required": [],
+                                    }))
+                                    .build().unwrap(),
+
+                                ChatCompletionFunctionsArgs::default()
+                                    .name("unmute_speech")
+                                    .description("Unmutes the AI voice so responses are spoken again.")
                                     .parameters(json!({
                                         "type": "object",
                                         "properties": {},

--- a/src/options.rs
+++ b/src/options.rs
@@ -33,6 +33,10 @@ pub struct Opt {
     #[arg(long)]
     pub tick: bool,
 
+    /// Start with the AI voice muted.
+    #[arg(long)]
+    pub mute: bool,
+
     /// The voice that the AI will use to speak.
     /// Choose from a list of available voices to customize the output.
     #[arg(long)]


### PR DESCRIPTION
## Summary
- let the assistant start muted with `--mute`
- allow `mute_speech`/`unmute_speech` function calls
- implement mute toggle in SpeakStream
- document mute option in README

## Testing
- `cargo fmt`
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68490ef7860c8332ac9ed2aafba5678e