### PR TITLE
Add audio output device management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ dependencies = [
  "futures",
  "hound",
  "humantime",
+ "once_cell",
  "open",
  "rdev",
  "rodio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ sysinfo = "0.32.1"
 csv = "1.3.1"
 humantime = "2.1.0"
 clipboard = "0.5.0"
+once_cell = "1.19.0"
 windows = { version = "0.52.0", features = [
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",


### PR DESCRIPTION
## Summary
- add once_cell dependency
- support selecting a global audio output device in `DefaultDeviceSink`
- expose functions to list and set output devices
- expose the new functions to the AI through `call_fn`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6849124cb02883329874a93e93b81c30