### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A push-to-talk AI voice assistant for your desktop.
 
-`quick-assistant` is a CLI program for your desktop. It allows the use to use a pre-designated push to talk key, to talk to a GPT-4 Turbo enabled AI assistant at any time. The assistant can respond back in both text and voice. Enabling natural sounding interaction. The AI can be interrupted even in the middle of speaking, for easy modifying and continuing of the conversation. 
+`quick-assistant` is a CLI program for your desktop. It allows the user to use a pre-designated push-to-talk key to talk to a GPT-4 Turbo–enabled AI assistant at any time. The assistant can respond in both text and voice, enabling natural-sounding interaction. The AI can be interrupted even while speaking for easy modification and continuation of the conversation.
 
 https://github.com/sloganking/quick-assistant/assets/16965931/a0c7469a-2c64-46e5-9ee9-dd9f9d56ea95
 
@@ -16,7 +16,7 @@ The assistant has functions for controlling the desktop. Such as:
 - Media playback control
 - Launching applications
 - Display its own log files
-- Get System information
+- Get system information
 - List and kill system processes
 - Run internet speed tests
 - Set timers that end in alarm sounds

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ enum Message {
 }
 
 fn error_and_panic(s: &str) -> ! {
-    error!("A fatal error occured: {}", s);
+    error!("A fatal error occurred: {}", s);
     panic!("{}", s);
 }
 
@@ -1287,7 +1287,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                                 ChatCompletionFunctionsArgs::default()
                                     .name("open_application")
-                                    .description("naively opens an applicatin by pressing the super key to open system search and then types the name of the application and presses enter.")
+                                    .description("naively opens an application by pressing the super key to open system search and then types the name of the application and presses enter.")
                                     .parameters(json!({
                                         "type": "object",
                                         "properties": {
@@ -1595,7 +1595,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             ai_content += content;
 
                                             let mut last_non_empty_line_option = None;
-                                            // return the last non empy line and it's line number
+                                            // return the last non empty line and its line number
                                             for (line_num, line_content) in
                                                 ai_content.lines().enumerate()
                                             {
@@ -1723,7 +1723,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             info!("System ready");
 
-            // Have this main thread recieve events and send them to the key handler thread
+            // Have this main thread receive events and send them to the key handler thread
             {
                 // We send keys as a message in a channel instead of putting the key handler
                 // inside the callback function because the operating system's mouse and


### PR DESCRIPTION
## Summary
- fix typos in README
- correct typos in code comments and error messages

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68492472eaf48332b2f62d88c582cb1f