### PR TITLE
Fix AI voice error handling

### DIFF
--- a/src/speakstream.rs
+++ b/src/speakstream.rs
@@ -420,6 +420,11 @@ pub mod ss {
                                     }
                                 }
 
+                                // Any outstanding conversions are aborted above
+                                // when a push-to-talk kill signal is received,
+                                // so reaching this branch means the conversion
+                                // itself failed. Queue the error audio so it's
+                                // played in sequence with other speech.
                                 ai_audio_playing_tx.send(AudioTask::Error).unwrap();
                                 let _ = thread_state_tx.send(SpeakState::Idle);
                             }

--- a/src/speakstream.rs
+++ b/src/speakstream.rs
@@ -10,6 +10,7 @@ pub mod ss {
 
     use crate::default_device_sink::DefaultDeviceSink;
     use crate::FAILED_TEMP_FILE;
+    use crate::PLAY_AUDIO;
     use std::fs::File;
     use std::io::{BufReader, Write};
     use std::path::Path;
@@ -213,6 +214,7 @@ pub mod ss {
                         "Failed to turn text to speech due to timeout: {:?}",
                         err
                     ));
+                    PLAY_AUDIO(FAILED_TEMP_FILE.path());
                     return None;
                 }
             };
@@ -221,6 +223,7 @@ pub mod ss {
             Ok(res) => res,
             Err(err) => {
                 println_error(&format!("Failed to turn text to speech: {:?}", err));
+                PLAY_AUDIO(FAILED_TEMP_FILE.path());
                 return None;
             }
         };
@@ -241,6 +244,7 @@ pub mod ss {
             Ok(Ok(())) => {}
             Ok(Err(err)) => {
                 println_error(&format!("Failed to save ai speech to file: {:?}", err));
+                PLAY_AUDIO(FAILED_TEMP_FILE.path());
                 return None;
             }
             Err(err) => {
@@ -248,6 +252,7 @@ pub mod ss {
                     "Failed to save ai speech to file due to timeout: {:?}",
                     err
                 ));
+                PLAY_AUDIO(FAILED_TEMP_FILE.path());
                 return None;
             }
         }


### PR DESCRIPTION
## Summary
- play failure sound if text-to-speech conversion fails

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a098d74108332a02d4ee615d163c2