### PR TITLE
Add OpenAI billing opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://github.com/sloganking/quick-assistant/assets/16965931/a0c7469a-2c64-46e5
 - ⏱️ **Timers** with alarm sounds
 - 🎙️ **Change voice** or speaking speed on the fly
 - 🔕 **Mute/unmute** the voice output
+- 💸 **Open OpenAI billing** page in the browser
 
 ## Setup
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,7 @@ use tempfile::Builder;
 mod record;
 use crate::default_device_sink::{
     default_device_name as get_default_output_device,
-    list_output_devices as list_audio_output_devices,
-    set_output_device,
-    DefaultDeviceSink,
+    list_output_devices as list_audio_output_devices, set_output_device, DefaultDeviceSink,
 };
 use async_openai::{
     types::{
@@ -286,6 +284,10 @@ fn call_fn(
                 Err(e) => Some(String::from("Showing logs folder failed with: ") + &e.to_string()), // If unwrap fails, return Some with the error message
             }
         }
+        "open_openai_billing" => match open::that("https://platform.openai.com/usage?tab=month") {
+            Ok(_) => None,
+            Err(e) => Some(format!("Failed to open OpenAI billing page: {}", e)),
+        },
         "sysinfo" => Some(get_system_info()),
 
         "get_system_processes" => Some(get_system_processes()),
@@ -1353,6 +1355,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     .build().unwrap(),
 
                                 ChatCompletionFunctionsArgs::default()
+                                    .name("open_openai_billing")
+                                    .description("Opens the OpenAI usage dashboard for this month in the default web browser.")
+                                    .parameters(json!({
+                                        "type": "object",
+                                        "properties": {},
+                                        "required": [],
+                                    }))
+                                    .build().unwrap(),
+
+                                ChatCompletionFunctionsArgs::default()
                                     .name("sysinfo")
                                     .description("Returns this system's information.")
                                     .parameters(json!({
@@ -1510,7 +1522,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         "required": [],
                                     }))
                                     .build().unwrap(),
-                              
+
                               ChatCompletionFunctionsArgs::default()
                                     .name("get_location")
                                     .description("Returns an approximate location based on the machine's IP address.")


### PR DESCRIPTION
## Summary
- open the OpenAI usage page via `open_openai_billing`
- allow the AI to call this new function
- document the feature in the README

## Testing
- `cargo fmt`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68522c4c5afc83328dcecb3d8128c0ef