### PR TITLE
Add basic test suite

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,28 @@ fn println_error(err: &str) {
     warn!("{}", err);
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string() {
+        assert_eq!(truncate("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn parse_voice_and_voice_to_str_roundtrip() {
+        let voice = parse_voice("Alloy").expect("voice should parse");
+        assert_eq!(voice_to_str(&voice), "alloy");
+        assert!(parse_voice("doesnotexist").is_none());
+    }
+}
+
 /// Creates a temporary file from a byte slice and returns the path to the file.
 fn create_temp_file_from_bytes(bytes: &[u8], extension: &str) -> NamedTempFile {
     let temp_file = Builder::new()

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -227,3 +227,31 @@ impl AudibleTimers {
         self.audio_stop_tx.send(()).unwrap();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use chrono::{Local, Duration};
+    use std::env;
+
+    #[test]
+    fn set_get_delete_timer() {
+        let tmp = tempdir().unwrap();
+        env::set_var("XDG_CACHE_HOME", tmp.path());
+        std::fs::create_dir_all(tmp.path().join("quick-assistant")).unwrap();
+
+        // Ensure no timers initially
+        assert!(get_timers().is_empty());
+
+        let t = Local::now() + Duration::seconds(1);
+        set_timer("test".to_string(), t).unwrap();
+
+        let timers = get_timers();
+        assert_eq!(timers.len(), 1);
+        assert_eq!(timers[0].1, "test");
+
+        delete_timer(timers[0].0).unwrap();
+        assert!(get_timers().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for helper methods in main
- test timer add/remove logic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6853605ab73c8332a5a4fd2121a31ad6