### PR TITLE
Add speakstream crate logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -668,8 +668,9 @@ fn set_up_logging(logs_dir: &Path) -> WorkerGuard {
     } else {
         // Define a custom filter function
         let custom_filter = FilterFn::new(|metadata| {
-            // Allow logs from 'quick_assistant' at DEBUG level and above
-            metadata.target().starts_with("quick_assistant")
+            // Allow logs from this crate and from `speakstream` at DEBUG level and above
+            (metadata.target().starts_with("quick_assistant")
+                || metadata.target().starts_with("speakstream"))
                 && metadata.level() <= &tracing::Level::DEBUG
         });
         use tracing_subscriber::prelude::*;


### PR DESCRIPTION
## Summary
- include `speakstream` targets in tracing filter

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6853689aae508332bb8bb099edb9b679