### PR TITLE
Add clipboard feature and CLI speech options

### DIFF
--- a/assistant_v2/Cargo.toml
+++ b/assistant_v2/Cargo.toml
@@ -19,3 +19,6 @@ hound = "3.5.1"
 uuid = { version = "1.6.1", features = ["v4"] }
 tempfile = "3.10.1"
 tracing = "0.1"
+clap = { version = "4.4.6", features = ["derive"] }
+colored = "2.0.4"
+clipboard = "0.5.0"

--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -12,7 +12,7 @@ This document tracks which features from the original assistant have been implem
 | Get system info | Pending |
 | List and kill processes | Pending |
 | Run internet speed tests | Pending |
-| Set the clipboard contents | Pending |
+| Set the clipboard contents | Done |
 | Timers with alarm sounds | Pending |
 | Change voice or speaking speed | Pending |
 | Mute/unmute voice output | Pending |


### PR DESCRIPTION
## Summary
- add CLI flags for speech speed, ticking and PTT ducking
- color You/AI labels to match v1
- enable audio ducking in push-to-talk thread
- add `set_clipboard` function to v2
- mark clipboard feature as done in progress log

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68623887ab9083328c3974897bb2f670