### PR TITLE
Add speech controls to assistant_v2

### DIFF
--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -14,8 +14,8 @@ This document tracks which features from the original assistant have been implem
 | Run internet speed tests | Pending |
 | Set the clipboard contents | Done |
 | Timers with alarm sounds | Pending |
-| Change voice or speaking speed | Pending |
-| Mute/unmute voice output | Pending |
+| Change voice or speaking speed | Done |
+| Mute/unmute voice output | Done |
 | Open OpenAI billing page | Done |
 | Push-to-talk text-to-speech interface | Done |
 | Interrupt AI speech with push-to-talk | Done |


### PR DESCRIPTION
## Summary
- add voice parsing utilities in assistant_v2
- expose speech speed and voice control functions
- implement mute/unmute and speech speed handlers
- update feature progress
- test for new assistant_v2 functions

## Testing
- `cargo test`
- `cargo test --manifest-path assistant_v2/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6862481b22a88332bef04eac54cdbd34