### PR TITLE
Add function invocation logging to v2

### DIFF
--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -19,5 +19,6 @@ This document tracks which features from the original assistant have been implem
 | Open OpenAI billing page | Done |
 | Push-to-talk text-to-speech interface | Done |
 | Interrupt AI speech with push-to-talk | Done |
+| Log function invocation names | Done |
 
 Update this table as features are migrated and verified to work in `assistant_v2`.

--- a/assistant_v2/src/main.rs
+++ b/assistant_v2/src/main.rs
@@ -431,6 +431,7 @@ async fn handle_requires_action(
 
     if let Some(required_action) = &run_object.required_action {
         for tool in &required_action.submit_tool_outputs.tool_calls {
+            println!("{}{}", "Invoking function: ".purple(), tool.function.name);
             if tool.function.name == "get_current_temperature" {
                 tool_outputs.push(ToolsOutputs {
                     tool_call_id: Some(tool.id.clone()),


### PR DESCRIPTION
## Summary
- print function name whenever an assistant tool executes
- track `Log function invocation names` in feature progress

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68624bf6a7cc8332ada44bb74298c86e