### PR TITLE
Add media controls to assistant_v2

### DIFF
--- a/assistant_v2/Cargo.toml
+++ b/assistant_v2/Cargo.toml
@@ -23,3 +23,4 @@ clap = { version = "4.4.6", features = ["derive"] }
 colored = "2.0.4"
 clipboard = "0.5.0"
 open = "5.3.1"
+enigo = "0.1.3"

--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -6,7 +6,7 @@ This document tracks which features from the original assistant have been implem
 | --- | --- |
 | Screen brightness control | Done |
 | System volume adjustment (Windows only) | Pending |
-| Media playback commands | Pending |
+| Media playback commands | Done |
 | Launch applications from voice | Pending |
 | Display log files | Pending |
 | Get system info | Pending |

--- a/assistant_v2/src/main.rs
+++ b/assistant_v2/src/main.rs
@@ -13,6 +13,7 @@ use colored::Colorize;
 use dotenvy::dotenv;
 use futures::StreamExt;
 use open;
+use enigo::{Enigo, KeyboardControllable};
 use speakstream::ss::SpeakStream;
 use std::error::Error;
 use std::path::PathBuf;
@@ -141,6 +142,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     "type": "object",
                     "properties": {"brightness": {"type": "integer"}},
                     "required": ["brightness"],
+                })),
+                strict: None,
+            }
+            .into(),
+            FunctionObject {
+                name: "media_controls".into(),
+                description: Some("Plays, pauses or seeks media.".into()),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "media_button": {
+                            "type": "string",
+                            "enum": [
+                                "MediaStop",
+                                "MediaNextTrack",
+                                "MediaPlayPause",
+                                "MediaPrevTrack",
+                                "VolumeUp",
+                                "VolumeDown",
+                                "VolumeMute"
+                            ]
+                        }
+                    },
+                    "required": ["media_button"]
                 })),
                 strict: None,
             }
@@ -483,6 +508,56 @@ async fn handle_requires_action(
                 });
             }
 
+            if tool.function.name == "media_controls" {
+                let button = match serde_json::from_str::<serde_json::Value>(&tool.function.arguments) {
+                    Ok(v) => v["media_button"].as_str().unwrap_or("").to_string(),
+                    Err(_) => String::new(),
+                };
+
+                let mut enigo = Enigo::new();
+                let msg = match button.as_str() {
+                    "MediaStop" => {
+                        enigo.key_click(enigo::Key::MediaStop);
+                        "MediaStop"
+                    }
+                    "MediaNextTrack" => {
+                        enigo.key_click(enigo::Key::MediaNextTrack);
+                        "MediaNextTrack"
+                    }
+                    "MediaPlayPause" => {
+                        enigo.key_click(enigo::Key::MediaPlayPause);
+                        "MediaPlayPause"
+                    }
+                    "MediaPrevTrack" => {
+                        enigo.key_click(enigo::Key::MediaPrevTrack);
+                        enigo.key_click(enigo::Key::MediaPrevTrack);
+                        "MediaPrevTrack"
+                    }
+                    "VolumeUp" => {
+                        for _ in 0..5 {
+                            enigo.key_click(enigo::Key::VolumeUp);
+                        }
+                        "VolumeUp"
+                    }
+                    "VolumeDown" => {
+                        for _ in 0..5 {
+                            enigo.key_click(enigo::Key::VolumeDown);
+                        }
+                        "VolumeDown"
+                    }
+                    "VolumeMute" => {
+                        enigo.key_click(enigo::Key::VolumeMute);
+                        "VolumeMute"
+                    }
+                    _ => "Unknown button",
+                };
+
+                tool_outputs.push(ToolsOutputs {
+                    tool_call_id: Some(tool.id.clone()),
+                    output: Some(msg.into()),
+                });
+            }
+
             if tool.function.name == "open_openai_billing" {
                 let result = open::that("https://platform.openai.com/usage");
                 let msg = match result {
@@ -706,6 +781,46 @@ mod tests {
         assert!(tools.iter().any(|t| match t {
             async_openai::types::AssistantTools::Function(f) =>
                 f.function.name == "set_speech_speed",
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn includes_media_controls_function() {
+        let req = CreateAssistantRequestArgs::default()
+            .instructions("test")
+            .model("gpt-4o")
+            .tools(vec![FunctionObject {
+                name: "media_controls".into(),
+                description: Some("Plays, pauses or seeks media.".into()),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "media_button": {
+                            "type": "string",
+                            "enum": [
+                                "MediaStop",
+                                "MediaNextTrack",
+                                "MediaPlayPause",
+                                "MediaPrevTrack",
+                                "VolumeUp",
+                                "VolumeDown",
+                                "VolumeMute"
+                            ]
+                        }
+                    },
+                    "required": ["media_button"]
+                })),
+                strict: None,
+            }
+            .into()])
+            .build()
+            .unwrap();
+
+        let tools = req.tools.unwrap();
+        assert!(tools.iter().any(|t| match t {
+            async_openai::types::AssistantTools::Function(f) =>
+                f.function.name == "media_controls",
             _ => false,
         }));
     }


### PR DESCRIPTION
## Summary
- add `enigo` as a dependency for simulating media keys
- implement `media_controls` function for v2 with support for play, stop and other buttons
- test that `media_controls` function is registered
- mark media playback as done in feature tracker

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68624c631e988332aacd93b70a233135