### PR TITLE
Add system info feature to v2

### DIFF
--- a/assistant_v2/Cargo.lock
+++ b/assistant_v2/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "rdev",
  "serde_json",
  "speakstream",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tracing",
@@ -680,6 +681,25 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1643,6 +1663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2521,6 +2570,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]

--- a/assistant_v2/Cargo.toml
+++ b/assistant_v2/Cargo.toml
@@ -23,3 +23,4 @@ clap = { version = "4.4.6", features = ["derive"] }
 colored = "2.0.4"
 clipboard = "0.5.0"
 open = "5.3.1"
+sysinfo = "0.32.1"

--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -9,7 +9,7 @@ This document tracks which features from the original assistant have been implem
 | Media playback commands | Pending |
 | Launch applications from voice | Pending |
 | Display log files | Pending |
-| Get system info | Pending |
+| Get system info | Done |
 | List and kill processes | Pending |
 | Run internet speed tests | Pending |
 | Set the clipboard contents | Done |

--- a/assistant_v2/src/main.rs
+++ b/assistant_v2/src/main.rs
@@ -29,6 +29,7 @@ use record::rec;
 use std::thread;
 use tempfile::tempdir;
 use uuid::Uuid;
+use sysinfo::{Components, Disks, Networks, System};
 
 #[derive(Parser, Debug)]
 struct Opt {
@@ -161,6 +162,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 description: Some(
                     "Opens the OpenAI usage dashboard in the default web browser.".into(),
                 ),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                })),
+                strict: None,
+            }
+            .into(),
+            FunctionObject {
+                name: "get_system_info".into(),
+                description: Some("Returns system information like CPU and memory usage.".into()),
                 parameters: Some(serde_json::json!({
                     "type": "object",
                     "properties": {},
@@ -422,6 +434,62 @@ fn start_ptt_thread(
     });
 }
 
+fn get_system_info() -> String {
+    let mut info = String::new();
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    info.push_str("=> system:\n");
+
+    let total_memory = sys.total_memory();
+    let used_memory = sys.used_memory();
+    let total_swap = sys.total_swap();
+    let used_swap = sys.used_swap();
+
+    info.push_str(&format!("total memory: {} bytes\n", total_memory));
+    info.push_str(&format!("used memory : {} bytes\n", used_memory));
+    info.push_str(&format!("total swap  : {} bytes\n", total_swap));
+    info.push_str(&format!("used swap   : {} bytes\n", used_swap));
+
+    let system_name = System::name();
+    let kernel_version = System::kernel_version();
+    let os_version = System::os_version();
+    let host_name = System::host_name();
+
+    info.push_str(&format!("System name:             {:?}\n", system_name));
+    info.push_str(&format!("System kernel version:   {:?}\n", kernel_version));
+    info.push_str(&format!("System OS version:       {:?}\n", os_version));
+    info.push_str(&format!("System host name:        {:?}\n", host_name));
+
+    let nb_cpus = sys.cpus().len();
+    info.push_str(&format!("NB CPUs: {}\n", nb_cpus));
+
+    info.push_str("=> disks:\n");
+    let disks = Disks::new_with_refreshed_list();
+    for disk in &disks {
+        info.push_str(&format!("{:?}\n", disk));
+    }
+
+    info.push_str("=> networks:\n");
+    let networks = Networks::new_with_refreshed_list();
+    for (interface_name, data) in &networks {
+        info.push_str(&format!(
+            "{}: {} B (down) / {} B (up)\n",
+            interface_name,
+            data.total_received(),
+            data.total_transmitted(),
+        ));
+    }
+
+    info.push_str("=> components:\n");
+    let components = Components::new_with_refreshed_list();
+    for component in &components {
+        info.push_str(&format!("{:?}\n", component));
+    }
+
+    info
+}
+
 async fn handle_requires_action(
     client: Client<OpenAIConfig>,
     run_object: RunObject,
@@ -551,6 +619,14 @@ async fn handle_requires_action(
                 tool_outputs.push(ToolsOutputs {
                     tool_call_id: Some(tool.id.clone()),
                     output: Some(msg.into()),
+                });
+            }
+
+            if tool.function.name == "get_system_info" {
+                let info = get_system_info();
+                tool_outputs.push(ToolsOutputs {
+                    tool_call_id: Some(tool.id.clone()),
+                    output: Some(info.into()),
                 });
             }
 
@@ -732,6 +808,32 @@ mod tests {
         let tools = req.tools.unwrap();
         assert!(tools.iter().any(|t| match t {
             async_openai::types::AssistantTools::Function(f) => f.function.name == "mute_speech",
+            _ => false,
+        }));
+    }
+
+    #[test]
+    fn includes_get_system_info_function() {
+        let req = CreateAssistantRequestArgs::default()
+            .instructions("test")
+            .model("gpt-4o")
+            .tools(vec![FunctionObject {
+                name: "get_system_info".into(),
+                description: Some("Returns system information like CPU and memory usage.".into()),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                })),
+                strict: None,
+            }
+            .into()])
+            .build()
+            .unwrap();
+
+        let tools = req.tools.unwrap();
+        assert!(tools.iter().any(|t| match t {
+            async_openai::types::AssistantTools::Function(f) => f.function.name == "get_system_info",
             _ => false,
         }));
     }


### PR DESCRIPTION
## Summary
- add sysinfo dependency
- provide system info function in assistant_v2
- update tools vector and tests
- mark system info port as done

## Testing
- `cargo test --all`
- `cargo test --manifest-path assistant_v2/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68624c194b088332b832b5c7b33ee122