### PR TITLE
Add CLI flag for SpeakStream audio ducking

### DIFF
--- a/assistant_v2/src/main.rs
+++ b/assistant_v2/src/main.rs
@@ -42,6 +42,10 @@ struct Opt {
     #[arg(long, default_value_t = false)]
     tick: bool,
 
+    /// Enable audio ducking while the assistant is speaking.
+    #[arg(long, default_value_t = false)]
+    duck: bool,
+
     /// Enable audio ducking while the push-to-talk key is held.
     #[arg(long, default_value_t = false)]
     duck_ptt: bool,
@@ -290,7 +294,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Voice::Echo,
         opt.speech_speed,
         opt.tick,
-        opt.duck_ptt,
+        opt.duck,
     )));
 
     let (audio_tx, audio_rx) = flume::unbounded();

--- a/src/main.rs
+++ b/src/main.rs
@@ -976,7 +976,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(voice) => voice.into(),
         None => Voice::Echo,
     };
-    let mut speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick, true);
+    let mut speak_stream = ss::SpeakStream::new(ai_voice, opt.speech_speed, opt.tick, opt.duck);
     if opt.mute {
         speak_stream.mute();
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,6 +32,10 @@ pub struct Opt {
     #[arg(long)]
     pub tick: bool,
 
+    /// Duck other application audio while the assistant is speaking.
+    #[arg(long)]
+    pub duck: bool,
+
     /// Duck other application audio while the push-to-talk key is held down.
     #[arg(long)]
     pub duck_ptt: bool,


### PR DESCRIPTION
## Summary
- control automatic audio ducking with `--duck`
- plumb the new flag through main and v2

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68694db895c48332b16b86c1de1b12a0