### PR TITLE
Add clipboard reader function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/sloganking/quick-assistant/assets/16965931/a0c7469a-2c64-46e5
 - 🗑️ **List and kill processes** by voice
 - 🌐 **Run internet speed tests**
 - 📋 **Set the clipboard** contents
+- 📋 **Get the clipboard** contents
 - 🔳 **Copy text as a QR code image** to the clipboard
 - ⏱️ **Timers** with alarm sounds
 - 🎙️ **Change voice** or speaking speed on the fly

--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -13,6 +13,7 @@ This document tracks which features from the original assistant have been implem
 | List and kill processes | Pending |
 | Run internet speed tests | Pending |
 | Set the clipboard contents | Done |
+| Get the clipboard contents | Done |
 | Timers with alarm sounds | Pending |
 | Change voice or speaking speed | Done |
 | Mute/unmute voice output | Done |


### PR DESCRIPTION
## Summary
- enable reading clipboard text via new `get_clipboard` tool
- document the new capability in README
- mark clipboard reading done in feature progress
- test clipboard roundtrip for both projects

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687afe1f3dc48332bb10b994050abca2