### PR TITLE
Add process controls to v2

### DIFF
--- a/assistant_v2/Cargo.lock
+++ b/assistant_v2/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "rdev",
  "serde_json",
  "speakstream",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tracing",
@@ -680,6 +681,25 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1643,6 +1663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2521,6 +2570,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys 0.8.7",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]

--- a/assistant_v2/Cargo.toml
+++ b/assistant_v2/Cargo.toml
@@ -23,3 +23,4 @@ clap = { version = "4.4.6", features = ["derive"] }
 colored = "2.0.4"
 clipboard = "0.5.0"
 open = "5.3.1"
+sysinfo = "0.32.1"

--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -10,7 +10,7 @@ This document tracks which features from the original assistant have been implem
 | Launch applications from voice | Pending |
 | Display log files | Pending |
 | Get system info | Pending |
-| List and kill processes | Pending |
+| List and kill processes | Done |
 | Run internet speed tests | Pending |
 | Set the clipboard contents | Done |
 | Timers with alarm sounds | Pending |


### PR DESCRIPTION
## Summary
- support viewing and killing processes in assistant_v2
- record feature parity progress
- depend on `sysinfo`
- test new assistant_v2 tools

## Testing
- `cargo test`
- `cargo test --manifest-path assistant_v2/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68624c2662d88332a6dbb9a085530029