### PR TITLE
Handle empty transcription in v2

### DIFF
--- a/assistant_v2/FEATURE_PROGRESS.md
+++ b/assistant_v2/FEATURE_PROGRESS.md
@@ -21,5 +21,6 @@ This document tracks which features from the original assistant have been implem
 | Push-to-talk text-to-speech interface | Done |
 | Interrupt AI speech with push-to-talk | Done |
 | Log function invocation names | Done |
+| Handle empty transcription results | Done |
 
 Update this table as features are migrated and verified to work in `assistant_v2`.

--- a/assistant_v2/src/main.rs
+++ b/assistant_v2/src/main.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing::info;
 
 mod record;
 mod transcribe;
@@ -334,6 +335,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let audio_path = audio_rx.recv().unwrap();
         interrupt_flag.store(false, Ordering::SeqCst);
         let transcription = transcribe::transcribe(&client, &audio_path).await?;
+        if transcription.trim().is_empty() {
+            println!("No transcription");
+            info!("User transcription was empty. Aborting LLM response.");
+            continue;
+        }
         println!("{}", "You: ".truecolor(0, 255, 0));
         println!("{}", transcription);
 


### PR DESCRIPTION
## Summary
- prevent crashes when speech transcription is empty
- note migration of this behaviour in progress tracker

## Testing
- `cargo test`
- `cargo test` in `assistant_v2`

------
https://chatgpt.com/codex/tasks/task_e_687c4aab6bc0833283d348b67f5392da